### PR TITLE
Typo correction in priority method

### DIFF
--- a/classes/email/driver.php
+++ b/classes/email/driver.php
@@ -149,9 +149,9 @@ abstract class Email_Driver {
 	 * @param	string		$priority			the message priority
 	 * @return	object		$this
 	 */
-	public function proirity($priority)
+	public function priority($priority)
 	{
-		$this->config['proirity'] = $priority;
+		$this->config['priority'] = $priority;
 		
 		return $this;
 	}


### PR DESCRIPTION
Changed the proirity method to priority. Also changed the config item to priority. This will now correctly pick up the email priority.

Existing code built upon the email package may need to be tweaked. (I couldn't see any reference to the old method within the package)
