### PR TITLE
Fixes #7 . Emails not showing in exception

### DIFF
--- a/classes/email/driver.php
+++ b/classes/email/driver.php
@@ -620,7 +620,18 @@ abstract class Email_Driver
 		if ($validate and ($failed = $this->validate_addresses()) !== true)
 		{
 			$this->invalid_addresses = $failed;
-			throw new \EmailValidationFailedException('One or more email addresses did not pass validation: '.implode(', ', $failed));
+			
+			$failed_emails = '';
+			foreach ($failed as $f)
+			{
+				if (isset($f['to']))
+				{
+					$failed_emails .= '"'.$f['to']['email'].'", ';
+				}
+			}
+			$failed_emails = substr($failed_emails, 0, -2);
+
+			throw new \EmailValidationFailedException('One or more email addresses did not pass validation: '.$failed_emails);
 		}
 
 		// Reset the headers


### PR DESCRIPTION
Now the exception is showing list of emails, like:

One or more email addresses did not pass validation: "trovster", "trovster2", ""
Example code:

```

        $email = \Email::forge();
        $email->subject('test');
        $email->html_body('body');
        $email->from('fuel');
        $email->to('trovster', 'Trevor');
        $email->to('trovster2', 'Trevor2');
        $email->to('', '');
        $email->priority(\Email::P_HIGH);
        $email->send();
```
