### PR TITLE
Changed get_content_type so it returns multipart/mixed to fix attachmen...

### DIFF
--- a/classes/email/driver.php
+++ b/classes/email/driver.php
@@ -850,11 +850,10 @@ abstract class Email_Driver
 		{
 			case 'plain':
 				return 'text/plain';
-			case 'plain_attach':
-			case 'html_attach':
-				return 'multipart/related; '.$boundary;
 			case 'html':
 				return 'text/html';
+			case 'plain_attach':
+			case 'html_attach':
 			case 'html_alt_attach':
 			case 'html_alt_inline_attach':
 				return 'multipart/mixed; '.$boundary;


### PR DESCRIPTION
...ts not showing in certain email clients (Apple Mail for Snow Leopard/Lion). According to RFC 2387 the Multipart/Related media type is intended for compound objects consisting of several inter-related body parts. This is not the case if you're adding additional attachments to an html email (as I was), so I changed it to mixed. Not sure if your mime designation has any additional function I failed to acknowledge, feel free to ignore this if so.
