### PR TITLE
Fixed incorrect trimming of cid

### DIFF
--- a/classes/email/driver.php
+++ b/classes/email/driver.php
@@ -488,7 +488,9 @@ abstract class Email_Driver
 		}
 
 		$disp = ($inline) ? 'inline' : 'attachment';
-		$cid = empty($cid) ? 'cid:'.md5($file[1]) : 'cid:'.ltrim($cid, 'cid:');
+		
+		$cid = empty($cid) ? 'cid:'.md5($file[1]) : trim($cid);
+		$cid = strpos($cid, 'cid:') === 0 ? $cid : 'cid:'.$cid;
 
 		// Fetch the file mime type.
 		$mime or $mime = static::attachment_mime($file[0]);
@@ -537,7 +539,8 @@ abstract class Email_Driver
 	public function string_attach($contents, $filename, $cid = null, $inline = false, $mime = null)
 	{
 		$disp = ($inline) ? 'inline' : 'attachment';
-		$cid = empty($cid) ? 'cid:'.md5($filename) : 'cid:'.ltrim($cid, 'cid:');
+		$cid = empty($cid) ? 'cid:'.md5($filename) : trim($cid);
+		$cid = strpos($cid, 'cid:') === 0 ? $cid : 'cid:'.$cid;	
 		$mime or $mime = static::attachment_mime($filename);
 
 		$this->attachments[$disp][$cid] = array(


### PR DESCRIPTION
The attach functions incorrectly trim the `$cid` 

```
'cid:'.ltrim($cid, 'cid:')
```

`ltrim` also removes 'c', 'ci', 'cid' or 'cid:' from the `$cid` md5, i.e.:

```
$cid = 'ce2e352a843c68a955a53b882f6567da';
$cid = 'cid:'.ltrim($cid, 'cid:');   //outputs "cid:e2e352a843c68a955a53b882f6567da" (missing c)
```

So the cid in the body of the message is not equal to the cid added to the attached file, which gives missing inline attachments.
