### PR TITLE
Return the value of $this->send() so information can be passed back from...

### DIFF
--- a/classes/email/driver.php
+++ b/classes/email/driver.php
@@ -758,10 +758,7 @@ abstract class Email_Driver
 			$this->alt_body = static::wrap_text($this->alt_body, $wrapping, $newline, false);
 		}
 
-		// Send
-		$this->_send();
-
-		return true;
+		return $this->send();
 	}
 
 	/**


### PR DESCRIPTION
Some drivers that use third party services may return a token or message ID, this allows them to be passed right back to the controller.
