### PR TITLE
Return-Path was rendered usesless when used with sendmail. Fixed by usin...

### DIFF
--- a/classes/email/driver/mail.php
+++ b/classes/email/driver/mail.php
@@ -23,7 +23,8 @@ class Email_Driver_Mail extends \Email_Driver
 	protected function _send()
 	{
 		$message = $this->build_message();
-		if ( ! @mail(static::format_addresses($this->to), $this->subject, $message['body'], $message['header'], '-oi -f '.$this->config['from']['email']))
+		$return_path = ($this->config['return_path'] !== false) ? $this->config['return_path'] : $this->config['from']['email'];
+		if ( ! @mail(static::format_addresses($this->to), $this->subject, $message['body'], $message['header'], '-oi -f '.$return_path))
 		{
 			throw new \EmailSendingFailedException('Failed sending email');
 		}

--- a/classes/email/driver/sendmail.php
+++ b/classes/email/driver/sendmail.php
@@ -30,7 +30,8 @@ class Email_Driver_Sendmail extends \Email_Driver
 		$message = $this->build_message();
 
 		// Open a connection
-		$handle = @popen($this->config['sendmail_path'] . " -oi -f ".$this->config['from']['email']." -t", 'w');
+		$return_path = ($this->config['return_path'] !== false) ? $this->config['return_path'] : $this->config['from']['email'];
+		$handle = @popen($this->config['sendmail_path'] . " -oi -f ".$return_path." -t", 'w');
 
 		// No connection?
 		if(! is_resource($handle))


### PR DESCRIPTION
Return-Path was rendered usesless when used with `sendmail`. Fixed by using `Return-Path` as envelope sender if available.

The `-f` option will always override the stated in `Return-path` header and all notification/bounce emails will be send to the `To` header.
