### PR TITLE
Fixed variable names in header method

### DIFF
--- a/classes/email/driver.php
+++ b/classes/email/driver.php
@@ -452,7 +452,7 @@ abstract class Email_Driver
 		{
 			foreach($header as $_header => $_value)
 			{
-				empty($value) or $this->extra_headers[$header] = $value;
+				empty($_value) or $this->extra_headers[$_header] = $_value;
 			}
 		}
 		else


### PR DESCRIPTION
Bug occurred when passing headers as an array.
