### PR TITLE
Pass filepath to pathinfo for attachments

### DIFF
--- a/classes/email/driver.php
+++ b/classes/email/driver.php
@@ -479,7 +479,7 @@ abstract class Email_Driver
 		// Ensure the attachment name
 		if ( ! isset($file[1]))
 		{
-			$name or $name = pathinfo($file, PATHINFO_BASENAME);
+			$name or $name = pathinfo($file[0], PATHINFO_BASENAME);
 			$file[] = $name;
 		}
 


### PR DESCRIPTION
This fixes a bug introduced by c44966b where an array was now being passed to pathinfo which causes:

```
Error: pathinfo() expects parameter 1 to be string, array given in fuel/packages/email/classes/email/driver.php on 482
```
