### PR TITLE
let the user decide to remove the html comments on html body emails

### DIFF
--- a/classes/email/driver.php
+++ b/classes/email/driver.php
@@ -213,9 +213,13 @@ abstract class Email_Driver
 		// Check settings
 		$generate_alt = is_bool($generate_alt) ? $generate_alt : $this->config['generate_alt'];
 		$auto_attach = is_bool($auto_attach) ? $auto_attach : $this->config['auto_attach'];
+		$remove_html_comments = ! empty($this->config['remove_html_comments']) ? $this->config['remove_html_comments'] : true;
 
 		// Remove html comments
-		$html = preg_replace('/<!--(.*)-->/', '', (string) $html);
+		if ($remove_html_comments)
+		{
+			$html = preg_replace('/<!--(.*)-->/', '', (string) $html);
+		}
 
 		if ($auto_attach)
 		{

--- a/config/email.php
+++ b/config/email.php
@@ -110,6 +110,11 @@ return array(
 			// relative to docroot.
 			DOCROOT,
 		),
+
+		/**
+		 * Remove html comments
+		 */
+		'remove_html_comments' => true,
 	),
 
 	/**


### PR DESCRIPTION
We use the email api as part of our CI suite and we _mark_ the html body using comments to check if everything is correct. 
We don't think that is up to the framework to decide if html comments **should or not** be stripped. That said, the framework should not alter the body other than the required manipulation to send the email.

I've added a new config parameter that let the user to decide if html comments should be removed 
