### PR TITLE
Trimming spaces from recipient email addresses

### DIFF
--- a/classes/email/driver.php
+++ b/classes/email/driver.php
@@ -727,7 +727,7 @@ abstract class Email_Driver
 		{
 			foreach ($this->{$list} as $recipient)
 			{
-				if ( ! filter_var($recipient['email'], FILTER_VALIDATE_EMAIL))
+				if ( ! filter_var(trim($recipient['email']), FILTER_VALIDATE_EMAIL))
 				{
 					$failed[$list][] = $recipient;
 				}


### PR DESCRIPTION
I know this should be the responsibility of the developer to clean their inputs, but does it hurt to trim here?
The issue is that the FILTER_VALIDATE_EMAIL fails if there's a space at the end of an email. 
