### PR TITLE
Fixing Regex for wrap_text

### DIFF
--- a/classes/email/driver.php
+++ b/classes/email/driver.php
@@ -1186,7 +1186,7 @@ abstract class Email_Driver
 	protected static function wrap_text($message, $length, $newline, $is_html = true)
 	{
 		$length = ($length > 76) ? 76 : $length;
-		$is_html and $message = preg_replace('/[\r|\n|\t]/m', '', $message);
+		$is_html and $message = preg_replace('/[\r\n\t]/m', '', $message);
 		$message = wordwrap($message, $length, $newline, false);
 
 		return $message;


### PR DESCRIPTION
The previous regex was capturing \r \n \t AND | (pipe)
However, pipe should not be getting matched
