### PR TITLE
Moves the timeout check outside the loop.

### DIFF
--- a/classes/email/driver/smtp.php
+++ b/classes/email/driver/smtp.php
@@ -288,18 +288,18 @@ class Email_Driver_Smtp extends \Email_Driver
 
 		while($str = fgets($this->smtp_connection, 512))
 		{
-			$info = stream_get_meta_data($this->smtp_connection);
-			if($info['timed_out'])
-			{
-				throw new \SmtpTimeoutException('SMTP connection timed out.');
-			}
-
 			$data .= $str;
 
 			if (substr($str, 3, 1) === ' ')
 			{
 				break;
 			}
+		}
+
+		$info = stream_get_meta_data($this->smtp_connection);
+		if($info['timed_out'])
+		{
+			throw new \SmtpTimeoutException('SMTP connection timed out.');
 		}
 
 		return $data;


### PR DESCRIPTION
- Moves the timeout check to outside of the loop so that the exception is thrown when a timeout occurs. This is because `fgets` returns `false` on a timeout and doesn't enter the loop.

PHP 5.6 seems to take longer than 5.4 to send e-mails and so I encountered this bug. After changing this I get the correct Exception and my code dies (as expected). Upping the timeout makes it succeed.

Before this change the timeout exception was not thrown and an empty string was returned (and because this was the HELP command which is optional the unexpected server response exception was ignored) causing the next piece of data to be the result of the last request (in this case) which caused an unexpected server response exception again.
