### PR TITLE
Fix RegEx in driver's minification process

### DIFF
--- a/classes/email/driver.php
+++ b/classes/email/driver.php
@@ -1186,7 +1186,7 @@ abstract class Email_Driver
 	protected static function wrap_text($message, $length, $newline, $is_html = true)
 	{
 		$length = ($length > 76) ? 76 : $length;
-		$is_html and $message = preg_replace('/[\r\n\t]/m', '', $message);
+		$is_html and $message = preg_replace('/[\r\n\t ]+/m', ' ', $message);
 		$message = wordwrap($message, $length, $newline, false);
 
 		return $message;


### PR DESCRIPTION
White space could be necessary, and it's complete removal might break it. For example, attributes for a tag might be listed beneath the tag - tab indented. The removal of new lines and tab characters left no space between the opening tag and the first attribute (subsequent attributes weren't an issue).

Also, multiple spaces can also be minified.

End result, convert any multiple instance of white space into a single space.

Example I was alerted to:

```
<td
    align="center"
```

Being converted to:

```
<tdalign="center"
```

Now being converted to:

```
<td align="center"
```
