### PR TITLE
Doubling dots breakes mail css styles

### DIFF
--- a/classes/email/driver/smtp.php
+++ b/classes/email/driver/smtp.php
@@ -80,7 +80,7 @@ class Email_Driver_Smtp extends \Email_Driver
 		// Prepare for data sending
 		$this->smtp_send('DATA', 354);
 
-		$lines = explode($this->config['newline'], $message['header'].preg_replace('/^\./m', '..$1', $message['body']));
+		$lines = explode($this->config['newline'], $message['header'].$message['body']);
 
 		foreach($lines as $line)
 		{


### PR DESCRIPTION
is there any reason for this ? preg_replace('/^./m', '..$1', $message['body'])

because it makes me this at html mails

```
<style> .some {background: black}
..other {color: white} </style>
```
