### PR TITLE
fix error when sending both inline attachments and normal attachments

### DIFF
--- a/classes/email/driver.php
+++ b/classes/email/driver.php
@@ -1038,6 +1038,7 @@ abstract class Email_Driver
 			case 'html':
 				return 'text/html';
 			case 'html_alt_attach':
+			case 'html_inline_attach':
 			case 'html_alt_inline_attach':
 				return 'multipart/mixed; '.$boundary;
 			case 'html_alt_inline':


### PR DESCRIPTION
"ERROR Invalid content-typehtml_inline_attach" because the email driver is not considering "html_inline_attach" as a valid content type.

This line fixes that issue