### PR TITLE
Added ability to specify the Mailgun API endpoint URL

### DIFF
--- a/classes/email/driver/mailgun.php
+++ b/classes/email/driver/mailgun.php
@@ -20,14 +20,24 @@ class Email_Driver_Mailgun extends \Email_Driver
 
 		$message = $this->build_message();
 
-		$mg = \Mailgun\Mailgun::create($this->config['mailgun']['key']);
-		
+		$config_mailgun = $this->config['mailgun'];
+
+		$endpoint = isset($config_mailgun['endpoint']) ? $config_mailgun['endpoint'] : null;
+
+		if (empty($endpoint)) {
+			$mg = \Mailgun\Mailgun::create($config_mailgun['key']);
+		}
+		else
+		{
+			$mg = \Mailgun\Mailgun::create($config_mailgun['key'], $endpoint);
+		}
+
 		// Mailgun does not consider these "arbitrary headers"
 		$exclude = array('From'=>'From', 'To'=>'To', 'Cc'=>'Cc', 'Bcc'=>'Bcc', 'Subject'=>'Subject', 'Content-Type'=>'Content-Type', 'Content-Transfer-Encoding' => 'Content-Transfer-Encoding');
 		$headers = array_diff_key($this->headers, $exclude);
 
 		foreach ($this->extra_headers as $header => $value) {
-		    $headers[$header] = $value;
+			$headers[$header] = $value;
 		}
 
 		// Standard required fields
@@ -59,7 +69,7 @@ class Email_Driver_Mailgun extends \Email_Driver
 		}
 
 		// And send the message out
-		$mg->messages()->send($this->config['mailgun']['domain'], $post_data);
+		$mg->messages()->send($config_mailgun['domain'], $post_data);
 
 		return true;
 	}

--- a/classes/email/driver/mailgun.php
+++ b/classes/email/driver/mailgun.php
@@ -24,7 +24,8 @@ class Email_Driver_Mailgun extends \Email_Driver
 
 		$endpoint = isset($config_mailgun['endpoint']) ? $config_mailgun['endpoint'] : null;
 
-		if (empty($endpoint)) {
+		if (empty($endpoint))
+		{
 			$mg = \Mailgun\Mailgun::create($config_mailgun['key']);
 		}
 		else
@@ -36,7 +37,8 @@ class Email_Driver_Mailgun extends \Email_Driver
 		$exclude = array('From'=>'From', 'To'=>'To', 'Cc'=>'Cc', 'Bcc'=>'Bcc', 'Subject'=>'Subject', 'Content-Type'=>'Content-Type', 'Content-Transfer-Encoding' => 'Content-Transfer-Encoding');
 		$headers = array_diff_key($this->headers, $exclude);
 
-		foreach ($this->extra_headers as $header => $value) {
+		foreach ($this->extra_headers as $header => $value)
+		{
 			$headers[$header] = $value;
 		}
 
@@ -56,15 +58,18 @@ class Email_Driver_Mailgun extends \Email_Driver
 		$this->alt_body and $post_data['text'] = $this->alt_body;
 
 		// Mailgun's "arbitrary headers" are h: prefixed
-		foreach ($headers as $name => $value) {
+		foreach ($headers as $name => $value)
+		{
 			$post_data["h:{$name}"] = $value;
 		}
 
-		foreach ($this->attachments['attachment'] as $cid => $file) {
+		foreach ($this->attachments['attachment'] as $cid => $file)
+		{
 			$post_data['attachment'][] = array('filePath' => $file['file'][0], 'remoteName' => $file['file'][1]);
 		}
 
-		foreach ($this->attachments['inline'] as $cid => $file) {
+		foreach ($this->attachments['inline'] as $cid => $file)
+		{
 			$post_data['inline'][] = array('filePath' => $file['file'][0], 'remoteName' => substr($cid, 4));
 		}
 

--- a/config/email.php
+++ b/config/email.php
@@ -168,6 +168,7 @@ return array(
 		'mailgun' => array(
 			'key'    => 'api_key',
 			'domain' => 'domain',
+			'endpoint' => null // optional API URL; example: 'https://api.eu.mailgun.net/v3'; to use default, omit entirely or set to null
 		),
 
 		/**

--- a/readme.md
+++ b/readme.md
@@ -142,7 +142,8 @@ return array(
 		'driver' => 'mailgun',
 		'mailgun' => array(
 			'key' => 'YOUR KEY',
-			'domain' => 'YOUR DOMAIN'
+			'domain' => 'YOUR DOMAIN',
+			'endpoint' => null | 'OPTIONAL ALT. API ENDPOINT URL' // e.g. 'https://api.eu.mailgun.net/v3'
 		),
 	),
 );


### PR DESCRIPTION
Submitting changes allowing for configuration of the Mailgun API URL. Sometimes this ability is needed when a domain is provisioned in a non-US region, but the current Mailgun driver does not allow for this.